### PR TITLE
[20090] Improve multiple task processing. Add additional QoS to endpoints.

### DIFF
--- a/sustainml_cpp/include/sustainml_cpp/core/Callable.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/core/Callable.hpp
@@ -21,6 +21,7 @@
 
 #include <functional>
 #include <iostream>
+#include <mutex>
 #include <tuple>
 
 #include <sustainml_cpp/config/Macros.hpp>
@@ -86,25 +87,43 @@ public:
      */
     template <std::size_t... Is>
     void invoke_user_cb(
-            helper::index<Is...>)
+            int task_id, helper::index<Is...>)
     {
-        on_new_task_available(*std::get<Is>(user_cb_args_)...);
+        tuple* args;
+        {
+            std::lock_guard<std::mutex> lock (mtx_);
+            args = &user_cb_args_[task_id];
+        }
+        on_new_task_available(*std::get<Is>(*args)...);
     }
 
     /**
      * @brief Returns the arguments with which the user callback
      * will be later invoked
      *
-     * @return Reference to the user callback args
+     * @return Reference to the user callback args (simple pointers)
      */
-    tuple& get_user_cb_args()
+    tuple& create_and_get_user_cb_args(const int& task_id)
     {
-        return user_cb_args_;
+        std::lock_guard<std::mutex> lock (mtx_);
+        user_cb_args_.insert({task_id, tuple()});
+        return user_cb_args_[task_id];
+    }
+
+    /**
+     * @brief Erases the element from the map by key
+     *
+     */
+    void remove_task_args(const int& task_id)
+    {
+        std::lock_guard<std::mutex> lock (mtx_);
+        user_cb_args_.erase(task_id);
     }
 
 private:
 
-    tuple user_cb_args_;
+    std::mutex mtx_;
+    std::map<int, tuple> user_cb_args_;
 #else
 
 public:

--- a/sustainml_cpp/include/sustainml_cpp/core/Callable.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/core/Callable.hpp
@@ -87,7 +87,8 @@ public:
      */
     template <std::size_t... Is>
     void invoke_user_cb(
-            int task_id, helper::index<Is...>)
+            int task_id,
+            helper::index<Is...>)
     {
         tuple* args;
         {
@@ -103,7 +104,8 @@ public:
      *
      * @return Reference to the user callback args (simple pointers)
      */
-    tuple& create_and_get_user_cb_args(const int& task_id)
+    tuple& create_and_get_user_cb_args(
+            const int& task_id)
     {
         std::lock_guard<std::mutex> lock (mtx_);
         user_cb_args_.insert({task_id, tuple()});
@@ -114,7 +116,8 @@ public:
      * @brief Erases the element from the map by key
      *
      */
-    void remove_task_args(const int& task_id)
+    void remove_task_args(
+            const int& task_id)
     {
         std::lock_guard<std::mutex> lock (mtx_);
         user_cb_args_.erase(task_id);

--- a/sustainml_cpp/include/sustainml_cpp/core/Node.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/core/Node.hpp
@@ -47,121 +47,126 @@ class DataReaderListener;
 namespace sustainml {
 namespace core {
 
-    class NodeImpl;
-    class NodeControlListener;
-    class Dispatcher;
-    struct Options;
+class NodeImpl;
+class NodeControlListener;
+class Dispatcher;
+struct Options;
+
+/**
+ * @brief This abstract class is the principal class of the project.
+ * Handles the DDS comunications, aggregates the dispatcher and provides
+ * the main methods for interacting with the user.
+ *
+ * This class is meant to be inherited by the different
+ * SustainML Nodes.
+ */
+class Node
+{
+
+    friend class Dispatcher;
+    template<class T> friend class SamplesQueue;
+    template<class T> friend class NodeListener;
+
+public:
+
+    SUSTAINML_CPP_DLL_API Node(
+            const std::string& name);
+
+    SUSTAINML_CPP_DLL_API Node(
+            const std::string& name,
+            const Options& opts);
+
+    SUSTAINML_CPP_DLL_API virtual ~Node();
 
     /**
-    * @brief This abstract class is the principal class of the project.
-    * Handles the DDS comunications, aggregates the dispatcher and provides
-    * the main methods for interacting with the user.
-    *
-    * This class is meant to be inherited by the different
-    * SustainML Nodes.
-    */
-    class Node
-    {
+     * @brief Called by the user to run the run.
+     */
+    SUSTAINML_CPP_DLL_API void spin();
 
-        friend class Dispatcher;
-        template<class T> friend class SamplesQueue;
-        template<class T> friend class NodeListener;
+    /**
+     * @brief Stops the execution of the node.
+     */
+    SUSTAINML_CPP_DLL_API static void terminate();
 
-    public:
+    /**
+     * @brief Retrieves the node name
+     */
+    SUSTAINML_CPP_DLL_API const std::string& name();
 
-        SUSTAINML_CPP_DLL_API Node(const std::string &name);
+    /**
+     * @brief Retrieves the node status
+     */
+    SUSTAINML_CPP_DLL_API const Status& status();
 
-        SUSTAINML_CPP_DLL_API Node(const std::string &name,
-                                   const Options &opts);
+protected:
 
-        SUSTAINML_CPP_DLL_API virtual ~Node();
-
-        /**
-        * @brief Called by the user to run the run.
-        */
-        SUSTAINML_CPP_DLL_API void spin();
-
-        /**
-        * @brief Stops the execution of the node.
-        */
-        SUSTAINML_CPP_DLL_API static void terminate();
-
-        /**
-        * @brief Retrieves the node name
-        */
-        SUSTAINML_CPP_DLL_API const std::string& name();
-
-        /**
-        * @brief Retrieves the node status
-        */
-        SUSTAINML_CPP_DLL_API const Status& status();
-
-    protected:
-
-        /**
-        * @brief Starts a new subscription (DataReader) in the
-        * given topic.
-        *
-        * @param topic The topic name
-        * @param type_name The type name
-        * @param listener Listener object inheriting from DataReaderListener
-        * @param opts Options to configure subscription QoS
-        */
-        bool initialize_subscription(
+    /**
+     * @brief Starts a new subscription (DataReader) in the
+     * given topic.
+     *
+     * @param topic The topic name
+     * @param type_name The type name
+     * @param listener Listener object inheriting from DataReaderListener
+     * @param opts Options to configure subscription QoS
+     */
+    bool initialize_subscription(
             const char* topic_name,
             const char* type_name,
             eprosima::fastdds::dds::DataReaderListener* listener,
-            const Options &opts);
+            const Options& opts);
 
-        /**
-        * @brief Starts a new publication (DataWriter) in the
-        * given topic.
-        *
-        * @param topic The topic name
-        * @param type_name The type name
-        * @param opts Options to configure publication QoS
-        */
-        bool initialize_publication(
+    /**
+     * @brief Starts a new publication (DataWriter) in the
+     * given topic.
+     *
+     * @param topic The topic name
+     * @param type_name The type name
+     * @param opts Options to configure publication QoS
+     */
+    bool initialize_publication(
             const char* topic_name,
             const char* type_name,
-            const Options &opts);
+            const Options& opts);
 
-        /**
-        * @brief Invokes the user callback with the provided inputs.
-        *
-        * @param inputs A vector containing the required samples. All the samples
-        * must correspond to the same task_id.
-        */
-        virtual void publish_to_user(const int& task_id, const std::vector<std::pair<int,void*>> inputs) = 0;
+    /**
+     * @brief Invokes the user callback with the provided inputs.
+     *
+     * @param inputs A vector containing the required samples. All the samples
+     * must correspond to the same task_id.
+     */
+    virtual void publish_to_user(
+            const int& task_id,
+            const std::vector<std::pair<int, void*>> inputs) = 0;
 
-        /**
-        * @brief Publishes the internal status of the node to DDS.
-        */
-        void publish_node_status();
+    /**
+     * @brief Publishes the internal status of the node to DDS.
+     */
+    void publish_node_status();
 
-        /**
-        * @brief Retrieves the node status
-        */
-        void status(const Status& status);
+    /**
+     * @brief Retrieves the node status
+     */
+    void status(
+            const Status& status);
 
-        /**
-        * @brief Retrieves the inner writers
-        */
-        const std::vector<eprosima::fastdds::dds::DataWriter*>& writers();
+    /**
+     * @brief Retrieves the inner writers
+     */
+    const std::vector<eprosima::fastdds::dds::DataWriter*>& writers();
 
-    private:
+private:
 
-        /**
-        * @brief Getter for the dispatcher
-        *
-        * @return A weak pointer to the Dispatcher object
-        */
-        std::weak_ptr<Dispatcher> get_dispatcher();
+    /**
+     * @brief Getter for the dispatcher
+     *
+     * @return A weak pointer to the Dispatcher object
+     */
+    std::weak_ptr<Dispatcher> get_dispatcher();
 
-        //! Impl
-        NodeImpl* impl_;
+    //! Impl
+    NodeImpl* impl_;
 
-    };
+};
 
 } // namespace core
 } // namespace sustainml

--- a/sustainml_cpp/include/sustainml_cpp/core/Node.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/core/Node.hpp
@@ -132,7 +132,7 @@ namespace core {
         * @param inputs A vector containing the required samples. All the samples
         * must correspond to the same task_id.
         */
-        virtual void publish_to_user(const std::vector<std::pair<int,void*>> inputs) = 0;
+        virtual void publish_to_user(const int& task_id, const std::vector<std::pair<int,void*>> inputs) = 0;
 
         /**
         * @brief Publishes the internal status of the node to DDS.

--- a/sustainml_cpp/include/sustainml_cpp/nodes/CarbonFootprintNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/CarbonFootprintNode.hpp
@@ -31,6 +31,11 @@ namespace sustainml {
 namespace core {
     template<class T> class QueuedNodeListener;
 }
+
+namespace utils {
+    template<class T> class SamplePool;
+}
+
 namespace co2_tracker_module {
 
     class Node;
@@ -107,7 +112,7 @@ namespace co2_tracker_module {
         * @param inputs A vector containing the required samples. All the samples
         * must correspond to the same task_id.
         */
-        void publish_to_user(const std::vector<std::pair<int, void*>> inputs) override;
+        void publish_to_user(const int& task_id, const std::vector<std::pair<int, void*>> inputs) override;
 
         CarbonFootprintTaskListener& user_listener_;
 
@@ -116,8 +121,8 @@ namespace co2_tracker_module {
         std::unique_ptr<core::QueuedNodeListener<types::HWResource>> listener_hw_queue_;
 
         std::mutex mtx_;
-        // task id to <NodeStatus, CO2Footprint>
-        std::map<int, std::pair<types::NodeStatus, types::CO2Footprint>>  task_data_;
+
+        std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::CO2Footprint>>> task_data_pool_;
     };
 
 } // namespace co2_tracker_module

--- a/sustainml_cpp/include/sustainml_cpp/nodes/HardwareResourcesNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/HardwareResourcesNode.hpp
@@ -29,93 +29,97 @@
 
 namespace sustainml {
 namespace core {
-    template<class T> class QueuedNodeListener;
-}
+template<class T> class QueuedNodeListener;
+} // namespace core
 
 namespace utils {
-    template<class T> class SamplePool;
-}
+template<class T> class SamplePool;
+} // namespace utils
 
 namespace hardware_module {
 
-    class Node;
-    class Dispatcher;
+class Node;
+class Dispatcher;
 
-    using HardwareResourcesCallable = core::Callable<types::MLModel, types::NodeStatus, types::HWResource>;
-    struct HardwareResourcesTaskListener : public HardwareResourcesCallable
+using HardwareResourcesCallable = core::Callable<types::MLModel, types::NodeStatus, types::HWResource>;
+struct HardwareResourcesTaskListener : public HardwareResourcesCallable
+{
+    virtual ~HardwareResourcesTaskListener()
     {
-        virtual ~HardwareResourcesTaskListener()
-        {
-        }
+    }
 
-        virtual void on_new_task_available(
-                types::MLModel& model,
-                types::NodeStatus& status,
-                types::HWResource& output) override
-        {
-        }
+    virtual void on_new_task_available(
+            types::MLModel& model,
+            types::NodeStatus& status,
+            types::HWResource& output) override
+    {
+    }
+
+};
+
+/**
+ * @brief Hardware Resources Node Implementation
+ * It requires the
+ * - ML Model
+ * as input
+ */
+class HardwareResourcesNode : public ::sustainml::core::Node
+{
+
+    enum ExpectedInputSamples
+    {
+        ML_MODEL_SAMPLE,
+        MAX
     };
 
-    /**
-    * @brief Hardware Resources Node Implementation
-    * It requires the
-    * - ML Model
-    * as input
-    */
-    class HardwareResourcesNode : public ::sustainml::core::Node
+    enum TaskData
     {
+        TASK_STATUS_DATA = ExpectedInputSamples::MAX,
+        TASK_OUTPUT_DATA
+    };
 
-        enum ExpectedInputSamples
-        {
-            ML_MODEL_SAMPLE,
-            MAX
-        };
+public:
 
-        enum TaskData
-        {
-            TASK_STATUS_DATA = ExpectedInputSamples::MAX,
-            TASK_OUTPUT_DATA
-        };
-
-    public:
-
-        SUSTAINML_CPP_DLL_API HardwareResourcesNode(
-                HardwareResourcesTaskListener& user_listener);
+    SUSTAINML_CPP_DLL_API HardwareResourcesNode(
+            HardwareResourcesTaskListener& user_listener);
 
 #ifndef SWIG_WRAPPER
-        SUSTAINML_CPP_DLL_API HardwareResourcesNode(
-                HardwareResourcesTaskListener& user_listener,
-                sustainml::core::Options opts);
+    SUSTAINML_CPP_DLL_API HardwareResourcesNode(
+            HardwareResourcesTaskListener& user_listener,
+            sustainml::core::Options opts);
 #endif // SWIG_WRAPPER
 
-        SUSTAINML_CPP_DLL_API virtual ~HardwareResourcesNode();
+    SUSTAINML_CPP_DLL_API virtual ~HardwareResourcesNode();
 
-    private:
+private:
 
-        /**
-         * @brief Initialize the DDS entities contained in the Node
-         *
-         * @param opts opts Options object with the QoS configuration
-         */
-        void init(const sustainml::core::Options& opts);
+    /**
+     * @brief Initialize the DDS entities contained in the Node
+     *
+     * @param opts opts Options object with the QoS configuration
+     */
+    void init(
+            const sustainml::core::Options& opts);
 
-        /**
-        * @brief Invokes the user callback with the provided inputs.
-        *
-        * @param inputs A vector containing the required samples. All the samples
-        * must correspond to the same task_id.
-        */
-        void publish_to_user(const int& task_id, const std::vector<std::pair<int, void*>> inputs) override;
+    /**
+     * @brief Invokes the user callback with the provided inputs.
+     *
+     * @param inputs A vector containing the required samples. All the samples
+     * must correspond to the same task_id.
+     */
+    void publish_to_user(
+            const int& task_id,
+            const std::vector<std::pair<int, void*>> inputs) override;
 
-        HardwareResourcesTaskListener& user_listener_;
+    HardwareResourcesTaskListener& user_listener_;
 
-        std::unique_ptr<core::QueuedNodeListener<types::MLModel>> listener_ml_model_queue_;
+    std::unique_ptr<core::QueuedNodeListener<types::MLModel>> listener_ml_model_queue_;
 
-        std::mutex mtx_;
+    std::mutex mtx_;
 
-        std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::HWResource>>> task_data_pool_;
+    std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::HWResource>>> task_data_pool_;
 
-    };
+};
 
 } // namespace hardware_module
 } // namespace sustainml

--- a/sustainml_cpp/include/sustainml_cpp/nodes/HardwareResourcesNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/HardwareResourcesNode.hpp
@@ -31,6 +31,11 @@ namespace sustainml {
 namespace core {
     template<class T> class QueuedNodeListener;
 }
+
+namespace utils {
+    template<class T> class SamplePool;
+}
+
 namespace hardware_module {
 
     class Node;
@@ -100,15 +105,15 @@ namespace hardware_module {
         * @param inputs A vector containing the required samples. All the samples
         * must correspond to the same task_id.
         */
-        void publish_to_user(const std::vector<std::pair<int, void*>> inputs) override;
+        void publish_to_user(const int& task_id, const std::vector<std::pair<int, void*>> inputs) override;
 
         HardwareResourcesTaskListener& user_listener_;
 
         std::unique_ptr<core::QueuedNodeListener<types::MLModel>> listener_ml_model_queue_;
 
         std::mutex mtx_;
-        //! task id to <NodeStatus, HWResource>
-        std::map<int, std::pair<types::NodeStatus, types::HWResource>>  task_data_;
+
+        std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::HWResource>>> task_data_pool_;
 
     };
 

--- a/sustainml_cpp/include/sustainml_cpp/nodes/MLModelNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/MLModelNode.hpp
@@ -29,93 +29,97 @@
 
 namespace sustainml {
 namespace core {
-    template<class T> class QueuedNodeListener;
-}
+template<class T> class QueuedNodeListener;
+} // namespace core
 
 namespace utils {
-    template<class T> class SamplePool;
-}
+template<class T> class SamplePool;
+} // namespace utils
 
 namespace ml_model_provider_module {
 
-    class Node;
-    class Dispatcher;
+class Node;
+class Dispatcher;
 
-    using MLModelCallable = core::Callable<types::EncodedTask, types::NodeStatus, types::MLModel>;
+using MLModelCallable = core::Callable<types::EncodedTask, types::NodeStatus, types::MLModel>;
 
-    struct MLModelTaskListener : public MLModelCallable
+struct MLModelTaskListener : public MLModelCallable
+{
+    virtual ~MLModelTaskListener()
     {
-        virtual ~MLModelTaskListener()
-        {
-        }
+    }
 
-        virtual void on_new_task_available(
-                types::EncodedTask& encoded_task,
-                types::NodeStatus& status,
-                types::MLModel& output) override
-        {
-        }
+    virtual void on_new_task_available(
+            types::EncodedTask& encoded_task,
+            types::NodeStatus& status,
+            types::MLModel& output) override
+    {
+    }
+
+};
+
+/**
+ * @brief Machine Learning Model Node Implementation
+ * It requires the
+ * - Encoded Task
+ * as input
+ */
+class MLModelNode : public ::sustainml::core::Node
+{
+    enum ExpectedInputSamples
+    {
+        ENCODED_TASK_SAMPLE,
+        MAX
     };
 
-    /**
-    * @brief Machine Learning Model Node Implementation
-    * It requires the
-    * - Encoded Task
-    * as input
-    */
-    class MLModelNode : public ::sustainml::core::Node
+    enum TaskData
     {
-        enum ExpectedInputSamples
-        {
-            ENCODED_TASK_SAMPLE,
-            MAX
-        };
+        TASK_STATUS_DATA = ExpectedInputSamples::MAX,
+        TASK_OUTPUT_DATA
+    };
 
-        enum TaskData
-        {
-            TASK_STATUS_DATA = ExpectedInputSamples::MAX,
-            TASK_OUTPUT_DATA
-        };
+public:
 
-    public:
-
-        SUSTAINML_CPP_DLL_API MLModelNode(
-                MLModelTaskListener& user_listener);
+    SUSTAINML_CPP_DLL_API MLModelNode(
+            MLModelTaskListener& user_listener);
 
 #ifndef SWIG_WRAPPER
-        SUSTAINML_CPP_DLL_API MLModelNode(
-                MLModelTaskListener& user_listener,
-                sustainml::core::Options opts);
+    SUSTAINML_CPP_DLL_API MLModelNode(
+            MLModelTaskListener& user_listener,
+            sustainml::core::Options opts);
 #endif // SWIG_WRAPPER
 
-        SUSTAINML_CPP_DLL_API virtual ~MLModelNode();
+    SUSTAINML_CPP_DLL_API virtual ~MLModelNode();
 
-    private:
+private:
 
-        /**
-         * @brief Initialize the DDS entities contained in the Node
-         *
-         * @param opts opts Options object with the QoS configuration
-         */
-        void init(const sustainml::core::Options& opts);
+    /**
+     * @brief Initialize the DDS entities contained in the Node
+     *
+     * @param opts opts Options object with the QoS configuration
+     */
+    void init(
+            const sustainml::core::Options& opts);
 
-        /**
-        * @brief Invokes the user callback with the provided inputs.
-        *
-        * @param inputs A vector containing the required samples. All the samples
-        * must correspond to the same task_id.
-        */
-        void publish_to_user(const int& task_id, const std::vector<std::pair<int, void*>> inputs) override;
+    /**
+     * @brief Invokes the user callback with the provided inputs.
+     *
+     * @param inputs A vector containing the required samples. All the samples
+     * must correspond to the same task_id.
+     */
+    void publish_to_user(
+            const int& task_id,
+            const std::vector<std::pair<int, void*>> inputs) override;
 
-        MLModelTaskListener& user_listener_;
+    MLModelTaskListener& user_listener_;
 
-        std::unique_ptr<core::QueuedNodeListener<types::EncodedTask>> listener_enc_task_queue_;
+    std::unique_ptr<core::QueuedNodeListener<types::EncodedTask>> listener_enc_task_queue_;
 
-        std::mutex mtx_;
+    std::mutex mtx_;
 
-        std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::MLModel>>> task_data_pool_;
+    std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::MLModel>>> task_data_pool_;
 
-    };
+};
 
 } // namespace ml_model_provider_module
 } // namespace sustainml

--- a/sustainml_cpp/include/sustainml_cpp/nodes/MLModelNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/MLModelNode.hpp
@@ -31,6 +31,11 @@ namespace sustainml {
 namespace core {
     template<class T> class QueuedNodeListener;
 }
+
+namespace utils {
+    template<class T> class SamplePool;
+}
+
 namespace ml_model_provider_module {
 
     class Node;
@@ -100,15 +105,15 @@ namespace ml_model_provider_module {
         * @param inputs A vector containing the required samples. All the samples
         * must correspond to the same task_id.
         */
-        void publish_to_user(const std::vector<std::pair<int, void*>> inputs) override;
+        void publish_to_user(const int& task_id, const std::vector<std::pair<int, void*>> inputs) override;
 
         MLModelTaskListener& user_listener_;
 
         std::unique_ptr<core::QueuedNodeListener<types::EncodedTask>> listener_enc_task_queue_;
 
         std::mutex mtx_;
-        //! task id to <NodeStatus, MLModel>
-        std::map<int, std::pair<types::NodeStatus, types::MLModel>>  task_data_;
+
+        std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::MLModel>>> task_data_pool_;
 
     };
 

--- a/sustainml_cpp/include/sustainml_cpp/nodes/TaskEncoderNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/TaskEncoderNode.hpp
@@ -31,6 +31,11 @@ namespace sustainml {
 namespace core {
     template<class T> class QueuedNodeListener;
 }
+
+namespace utils {
+    template<class T> class SamplePool;
+}
+
 namespace ml_task_encoding_module {
 
     class Node;
@@ -101,15 +106,15 @@ namespace ml_task_encoding_module {
         * @param inputs A vector containing the required samples. All the samples
         * must correspond to the same task_id.
         */
-        void publish_to_user(const std::vector<std::pair<int, void*>> inputs) override;
+        void publish_to_user(const int& task_id, const std::vector<std::pair<int, void*>> inputs) override;
 
         TaskEncoderTaskListener& user_listener_;
 
         std::unique_ptr<core::QueuedNodeListener<types::UserInput>> listener_user_input_queue_;
 
         std::mutex mtx_;
-        //! task id to <NodeStatus, EncodedTask>
-        std::map<int, std::pair<types::NodeStatus, types::EncodedTask>>  task_data_;
+
+        std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::EncodedTask>>> task_data_pool_;
 
     };
 

--- a/sustainml_cpp/include/sustainml_cpp/nodes/TaskEncoderNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/TaskEncoderNode.hpp
@@ -29,94 +29,98 @@
 
 namespace sustainml {
 namespace core {
-    template<class T> class QueuedNodeListener;
-}
+template<class T> class QueuedNodeListener;
+} // namespace core
 
 namespace utils {
-    template<class T> class SamplePool;
-}
+template<class T> class SamplePool;
+} // namespace utils
 
 namespace ml_task_encoding_module {
 
-    class Node;
-    class Dispatcher;
+class Node;
+class Dispatcher;
 
-    using TaskEncoderCallable = core::Callable<types::UserInput, types::NodeStatus, types::EncodedTask>;
+using TaskEncoderCallable = core::Callable<types::UserInput, types::NodeStatus, types::EncodedTask>;
 
-    struct TaskEncoderTaskListener : public TaskEncoderCallable
+struct TaskEncoderTaskListener : public TaskEncoderCallable
+{
+    virtual ~TaskEncoderTaskListener()
     {
-        virtual ~TaskEncoderTaskListener()
-        {
-        }
+    }
 
-        virtual void on_new_task_available(
-                types::UserInput& user_input,
-                types::NodeStatus& status,
-                types::EncodedTask& output) override
-        {
-        }
+    virtual void on_new_task_available(
+            types::UserInput& user_input,
+            types::NodeStatus& status,
+            types::EncodedTask& output) override
+    {
+    }
+
+};
+
+/**
+ * @brief Task Encoder Node Implementation
+ * It requires the
+ * - User Input
+ * as input
+ */
+class TaskEncoderNode : public ::sustainml::core::Node
+{
+
+    enum ExpectedInputSamples
+    {
+        USER_INPUT_SAMPLE,
+        MAX
     };
 
-    /**
-    * @brief Task Encoder Node Implementation
-    * It requires the
-    * - User Input
-    * as input
-    */
-    class TaskEncoderNode : public ::sustainml::core::Node
+    enum TaskData
     {
+        TASK_STATUS_DATA = ExpectedInputSamples::MAX,
+        TASK_OUTPUT_DATA
+    };
 
-        enum ExpectedInputSamples
-        {
-            USER_INPUT_SAMPLE,
-            MAX
-        };
+public:
 
-        enum TaskData
-        {
-            TASK_STATUS_DATA = ExpectedInputSamples::MAX,
-            TASK_OUTPUT_DATA
-        };
-
-    public:
-
-        SUSTAINML_CPP_DLL_API TaskEncoderNode(
-                TaskEncoderTaskListener& user_listener);
+    SUSTAINML_CPP_DLL_API TaskEncoderNode(
+            TaskEncoderTaskListener& user_listener);
 
 #ifndef SWIG_WRAPPER
-        SUSTAINML_CPP_DLL_API TaskEncoderNode(
-                TaskEncoderTaskListener& user_listener,
-                sustainml::core::Options opts);
+    SUSTAINML_CPP_DLL_API TaskEncoderNode(
+            TaskEncoderTaskListener& user_listener,
+            sustainml::core::Options opts);
 #endif // SWIG_WRAPPER
 
-        SUSTAINML_CPP_DLL_API virtual ~TaskEncoderNode();
+    SUSTAINML_CPP_DLL_API virtual ~TaskEncoderNode();
 
-    private:
+private:
 
-        /**
-         * @brief Initialize the DDS entities contained in the Node
-         *
-         * @param opts opts Options object with the QoS configuration
-         */
-        void init(const sustainml::core::Options& opts);
+    /**
+     * @brief Initialize the DDS entities contained in the Node
+     *
+     * @param opts opts Options object with the QoS configuration
+     */
+    void init(
+            const sustainml::core::Options& opts);
 
-        /**
-        * @brief Invokes the user callback with the provided inputs.
-        *
-        * @param inputs A vector containing the required samples. All the samples
-        * must correspond to the same task_id.
-        */
-        void publish_to_user(const int& task_id, const std::vector<std::pair<int, void*>> inputs) override;
+    /**
+     * @brief Invokes the user callback with the provided inputs.
+     *
+     * @param inputs A vector containing the required samples. All the samples
+     * must correspond to the same task_id.
+     */
+    void publish_to_user(
+            const int& task_id,
+            const std::vector<std::pair<int, void*>> inputs) override;
 
-        TaskEncoderTaskListener& user_listener_;
+    TaskEncoderTaskListener& user_listener_;
 
-        std::unique_ptr<core::QueuedNodeListener<types::UserInput>> listener_user_input_queue_;
+    std::unique_ptr<core::QueuedNodeListener<types::UserInput>> listener_user_input_queue_;
 
-        std::mutex mtx_;
+    std::mutex mtx_;
 
-        std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::EncodedTask>>> task_data_pool_;
+    std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::EncodedTask>>> task_data_pool_;
 
-    };
+};
 
 } // namespace ml_task_encoding_module
 } // namespace sustainml

--- a/sustainml_cpp/src/cpp/core/Dispatcher.cpp
+++ b/sustainml_cpp/src/cpp/core/Dispatcher.cpp
@@ -26,137 +26,144 @@
 namespace sustainml {
 namespace core {
 
-    Dispatcher::Dispatcher(Node *node) :
-        thread_pool_(N_THREADS_DEFAULT),
-        node_(node),
-        stop_(false),
-        started_(false)
-    {
-        sample_queryables_.reserve(INITIAL_N_QUEUES);
-    }
+Dispatcher::Dispatcher(
+        Node* node)
+    : thread_pool_(N_THREADS_DEFAULT)
+    , node_(node)
+    , stop_(false)
+    , started_(false)
+{
+    sample_queryables_.reserve(INITIAL_N_QUEUES);
+}
 
-    Dispatcher::~Dispatcher()
-    {
-        stop();
-    }
+Dispatcher::~Dispatcher()
+{
+    stop();
+}
 
-    bool Dispatcher::is_active()
-    {
-        return started_.load(std::memory_order_relaxed);
-    }
+bool Dispatcher::is_active()
+{
+    return started_.load(std::memory_order_relaxed);
+}
 
-    void Dispatcher::start()
+void Dispatcher::start()
+{
+    if (!started_)
     {
-        if (!started_)
+        thread_pool_.enable();
+
+        // Feed the routine in thread pool
+        thread_pool_.slot(
+            DISPATCHER_ROUTINE_ID,
+            std::bind(&Dispatcher::routine, this));
+
+        started_.store(true);
+    }
+}
+
+void Dispatcher::stop()
+{
+    thread_pool_.disable();
+}
+
+void Dispatcher::register_sample_queryable(
+        interfaces::SampleQueryable* sr)
+{
+    sample_queryables_.emplace_back(sr);
+}
+
+void Dispatcher::notify(
+        const int& task_id)
+{
+    if (started_.load(std::memory_order_relaxed))
+    {
         {
-            thread_pool_.enable();
-
-            // Feed the routine in thread pool
-            thread_pool_.slot(
-                DISPATCHER_ROUTINE_ID,
-                std::bind(&Dispatcher::routine, this));
-
-            started_.store(true);
+            std::unique_lock<std::mutex> lock(mtx_);
+            taskid_buffer_.push(task_id);
         }
-    }
 
-    void Dispatcher::stop()
-    {
-        thread_pool_.disable();
+        thread_pool_.emit(DISPATCHER_ROUTINE_ID);
     }
-
-    void Dispatcher::register_sample_queryable(interfaces::SampleQueryable* sr)
+    else
     {
-        sample_queryables_.emplace_back(sr);
+        EPROSIMA_LOG_ERROR(DISPATCHER,
+                node_->name() << " Dispatcher discarding sample with task_id " << task_id <<
+                ", not initialized");
     }
+}
 
-    void Dispatcher::notify(const int &task_id)
+void Dispatcher::process(
+        const int& task_id)
+{
+    int expected_hits = sample_queryables_.size();
+
+    bool all_received = false;
+
     {
-        if (started_.load(std::memory_order_relaxed))
+        std::lock_guard<std::mutex> lock(taskid_mtx_);
+        auto it = taskid_tracker_.find(task_id);
+
+        if (it == taskid_tracker_.end())
         {
-            {
-                std::unique_lock<std::mutex> lock(mtx_);
-                taskid_buffer_.push(task_id);
-            }
-
-            thread_pool_.emit(DISPATCHER_ROUTINE_ID);
+            EPROSIMA_LOG_INFO(DISPATCHER, node_->name() << " Initializing task_id " << task_id);
+            taskid_tracker_[task_id] = 1;
         }
         else
         {
-            EPROSIMA_LOG_ERROR(DISPATCHER, node_->name() << " Dispatcher discarding sample with task_id " << task_id << ", not initialized");
+            it->second += 1;
+            EPROSIMA_LOG_INFO(DISPATCHER,
+                    node_->name() << " Taskid_tracker_[task_id] " << task_id << " n_times " << it->second);
+        }
+
+        if (taskid_tracker_[task_id] == expected_hits)
+        {
+            all_received = true;
+            taskid_tracker_.erase(task_id);
         }
     }
 
-    void Dispatcher::process(const int& task_id)
+    if (all_received)
     {
-        int expected_hits = sample_queryables_.size();
+        std::vector<std::pair<int, void*>> samples;
+        samples.reserve(sample_queryables_.size());
 
-        bool all_received = false;
-
+        for (auto& sq : sample_queryables_)
         {
-            std::lock_guard<std::mutex> lock(taskid_mtx_);
-            auto it = taskid_tracker_.find(task_id);
+            void* sample = sq->retrieve_sample_from_taskid(task_id);
 
-            if (it == taskid_tracker_.end())
+            if (nullptr != sample)
             {
-                EPROSIMA_LOG_INFO(DISPATCHER, node_->name() << " Initializing task_id " << task_id);
-                taskid_tracker_[task_id] = 1;
+                samples.push_back(std::make_pair(sq->get_id(), sample));
             }
             else
             {
-                it->second +=1;
-                EPROSIMA_LOG_INFO(DISPATCHER,node_->name() << " Taskid_tracker_[task_id] " << task_id << " n_times " << it->second);
-            }
-
-            if (taskid_tracker_[task_id] == expected_hits)
-            {
-                all_received = true;
-                taskid_tracker_.erase(task_id);
+                return;
             }
         }
-
-        if (all_received)
-        {
-            std::vector<std::pair<int, void*>> samples;
-            samples.reserve(sample_queryables_.size());
-
-            for (auto& sq : sample_queryables_)
-            {
-                void* sample = sq->retrieve_sample_from_taskid(task_id);
-
-                if (nullptr != sample)
-                {
-                    samples.push_back(std::make_pair(sq->get_id(), sample));
-                }
-                else
-                {
-                    return;
-                }
-            }
-            node_->publish_to_user(task_id, samples);
-        }
+        node_->publish_to_user(task_id, samples);
     }
+}
 
-    void Dispatcher::routine()
+void Dispatcher::routine()
+{
+    int task_id{-1};
+
     {
-        int task_id{-1};
-
-        {
-            std::unique_lock<std::mutex> lock(mtx_);
-            task_id = taskid_buffer_.front();
-            taskid_buffer_.pop();
-        }
-
-        if (task_id != common::INVALID_ID)
-        {
-            process(task_id);
-        }
-        else
-        {
-            EPROSIMA_LOG_ERROR(DISPATCHER, "Invalid Task Id in queue");
-        }
-
+        std::unique_lock<std::mutex> lock(mtx_);
+        task_id = taskid_buffer_.front();
+        taskid_buffer_.pop();
     }
+
+    if (task_id != common::INVALID_ID)
+    {
+        process(task_id);
+    }
+    else
+    {
+        EPROSIMA_LOG_ERROR(DISPATCHER, "Invalid Task Id in queue");
+    }
+
+}
 
 } // namespace core
 } // namespace sustainml

--- a/sustainml_cpp/src/cpp/core/Dispatcher.cpp
+++ b/sustainml_cpp/src/cpp/core/Dispatcher.cpp
@@ -81,6 +81,10 @@ namespace core {
 
             thread_pool_.emit(DISPATCHER_ROUTINE_ID);
         }
+        else
+        {
+            EPROSIMA_LOG_ERROR(DISPATCHER, node_->name() << " Dispatcher discarding sample with task_id " << task_id << ", not initialized");
+        }
     }
 
     void Dispatcher::process(const int& task_id)
@@ -129,8 +133,7 @@ namespace core {
                     return;
                 }
             }
-
-            node_->publish_to_user(samples);
+            node_->publish_to_user(task_id, samples);
         }
     }
 

--- a/sustainml_cpp/src/cpp/core/NodeImpl.cpp
+++ b/sustainml_cpp/src/cpp/core/NodeImpl.cpp
@@ -86,6 +86,8 @@ namespace core {
             const std::string& name,
             const Options& opts)
     {
+        dispatcher_->start();
+
         auto dpf = DomainParticipantFactory::get_instance();
 
         //! Initialize entities
@@ -150,7 +152,6 @@ namespace core {
     void NodeImpl::spin()
     {
         EPROSIMA_LOG_INFO(NODE, "Spinning Node... ");
-        dispatcher_->start();
 
         node_status_.node_status(::NODE_IDLE);
         publish_node_status();

--- a/sustainml_cpp/src/cpp/core/NodeImpl.cpp
+++ b/sustainml_cpp/src/cpp/core/NodeImpl.cpp
@@ -32,242 +32,246 @@ using namespace eprosima::fastdds::dds;
 namespace sustainml {
 namespace core {
 
-    std::atomic<bool> NodeImpl::terminate_(false);
-    std::condition_variable NodeImpl::spin_cv_;
+std::atomic<bool> NodeImpl::terminate_(false);
+std::condition_variable NodeImpl::spin_cv_;
 
-    NodeImpl::NodeImpl(
-            Node* node,
-            const std::string &name) :
-        node_(node),
-        dispatcher_(new Dispatcher(node_)),
-        participant_(nullptr),
-        publisher_(nullptr),
-        subscriber_(nullptr),
-        control_listener_(this)
+NodeImpl::NodeImpl(
+        Node* node,
+        const std::string& name)
+    : node_(node)
+    , dispatcher_(new Dispatcher(node_))
+    , participant_(nullptr)
+    , publisher_(nullptr)
+    , subscriber_(nullptr)
+    , control_listener_(this)
+{
+    if (!init(name))
     {
-        if (!init(name))
-        {
-            EPROSIMA_LOG_ERROR(NODE, "Initialization Failed");
-        }
+        EPROSIMA_LOG_ERROR(NODE, "Initialization Failed");
     }
+}
 
-    NodeImpl::NodeImpl(
-            Node* node,
-            const std::string &name,
-            const Options& opts) :
-        node_(node),
-        dispatcher_(new Dispatcher(node_)),
-        participant_(nullptr),
-        publisher_(nullptr),
-        subscriber_(nullptr),
-        control_listener_(this)
+NodeImpl::NodeImpl(
+        Node* node,
+        const std::string& name,
+        const Options& opts)
+    : node_(node)
+    , dispatcher_(new Dispatcher(node_))
+    , participant_(nullptr)
+    , publisher_(nullptr)
+    , subscriber_(nullptr)
+    , control_listener_(this)
+{
+    if (!init(name, opts))
     {
-        if (!init(name, opts))
-        {
-            EPROSIMA_LOG_ERROR(NODE, "Initialization Failed with the provided Options");
-        }
+        EPROSIMA_LOG_ERROR(NODE, "Initialization Failed with the provided Options");
     }
+}
 
-    NodeImpl::~NodeImpl()
+NodeImpl::~NodeImpl()
+{
+    EPROSIMA_LOG_INFO(NODE, "Destroying Node");
+
+    if (nullptr != participant_)
     {
-        EPROSIMA_LOG_INFO(NODE, "Destroying Node");
-
-        if (nullptr != participant_)
-        {
-            participant_->delete_contained_entities();
-            auto dpf = DomainParticipantFactory::get_instance();
-            dpf->delete_participant(participant_);
-        }
-
-        dispatcher_->stop();
-    }
-
-    bool NodeImpl::init(
-            const std::string& name,
-            const Options& opts)
-    {
-        dispatcher_->start();
-
+        participant_->delete_contained_entities();
         auto dpf = DomainParticipantFactory::get_instance();
-
-        //! Initialize entities
-
-        participant_ = dpf->create_participant(opts.domain, opts.pqos);
-
-        if (participant_ == nullptr)
-        {
-            return false;
-        }
-
-        subscriber_ = participant_->create_subscriber(opts.subqos);
-
-        if (subscriber_ == nullptr)
-        {
-            return false;
-        }
-
-        publisher_ = participant_->create_publisher(opts.pubqos);
-
-        if (publisher_ == nullptr)
-        {
-            return false;
-        }
-
-        //! Register Common Types
-
-        std::vector<eprosima::fastdds::dds::TypeSupport> sustainml_types;
-        sustainml_types.reserve(common::Topics::MAX);
-
-        sustainml_types.push_back(static_cast<TypeSupport>(new NodeStatusImplPubSubType()));
-        sustainml_types.push_back(static_cast<TypeSupport>(new NodeControlImplPubSubType()));
-        sustainml_types.push_back(static_cast<TypeSupport>(new UserInputImplPubSubType()));
-        sustainml_types.push_back(static_cast<TypeSupport>(new EncodedTaskImplPubSubType()));
-        sustainml_types.push_back(static_cast<TypeSupport>(new MLModelImplPubSubType()));
-        sustainml_types.push_back(static_cast<TypeSupport>(new HWResourceImplPubSubType()));
-        sustainml_types.push_back(static_cast<TypeSupport>(new CO2FootprintImplPubSubType()));
-
-        for (auto &&type : sustainml_types)
-        {
-            participant_->register_type(type);
-        }
-
-        //! Initialize common topics
-        initialize_subscription(common::TopicCollection::get()[common::Topics::NODE_CONTROL].first.c_str(),
-                                common::TopicCollection::get()[common::Topics::NODE_CONTROL].second.c_str(),
-                                &control_listener_, opts);
-
-        initialize_publication(common::TopicCollection::get()[common::Topics::NODE_STATUS].first.c_str(),
-                                common::TopicCollection::get()[common::Topics::NODE_STATUS].second.c_str(),
-                                opts);
-
-        //! Initialize node
-        node_status_.node_name(name);
-        node_status_.node_status(::NODE_INITIALIZING);
-
-        publish_node_status();
-
-        return true;
+        dpf->delete_participant(participant_);
     }
 
-    void NodeImpl::spin()
+    dispatcher_->stop();
+}
+
+bool NodeImpl::init(
+        const std::string& name,
+        const Options& opts)
+{
+    dispatcher_->start();
+
+    auto dpf = DomainParticipantFactory::get_instance();
+
+    //! Initialize entities
+
+    participant_ = dpf->create_participant(opts.domain, opts.pqos);
+
+    if (participant_ == nullptr)
     {
-        EPROSIMA_LOG_INFO(NODE, "Spinning Node... ");
-
-        node_status_.node_status(::NODE_IDLE);
-        publish_node_status();
-
-        std::unique_lock<std::mutex> lock(spin_mtx_);
-        spin_cv_.wait(lock, [&]{ return terminate_.load();});
+        return false;
     }
 
-    bool NodeImpl::initialize_subscription(
-            const char* topic_name,
-            const char* type_name,
-            eprosima::fastdds::dds::DataReaderListener* listener,
-            const Options& opts)
+    subscriber_ = participant_->create_subscriber(opts.subqos);
+
+    if (subscriber_ == nullptr)
     {
-        Topic* topic = participant_->create_topic(topic_name, type_name, TOPIC_QOS_DEFAULT);
-
-        if (topic == nullptr)
-        {
-            return false;
-        }
-
-        DataReader* reader = subscriber_->create_datareader(topic, opts.rqos, listener);
-
-        if (reader == nullptr)
-        {
-            return false;
-        }
-
-        topics_.emplace_back(topic);
-        readers_.emplace_back(reader);
-
-        return true;
+        return false;
     }
 
-    bool NodeImpl::initialize_publication(
-            const char* topic_name,
-            const char* type_name,
-            const Options& opts)
+    publisher_ = participant_->create_publisher(opts.pubqos);
+
+    if (publisher_ == nullptr)
     {
-        Topic* topic = participant_->create_topic(topic_name, type_name, TOPIC_QOS_DEFAULT);
-
-        if (topic == nullptr)
-        {
-            return false;
-        }
-
-        DataWriter* writer = publisher_->create_datawriter(topic, opts.wqos);
-
-        if (writer == nullptr)
-        {
-            return false;
-        }
-
-        topics_.emplace_back(topic);
-        writers_.emplace_back(writer);
-
-        return true;
+        return false;
     }
 
-    void NodeImpl::publish_node_status()
+    //! Register Common Types
+
+    std::vector<eprosima::fastdds::dds::TypeSupport> sustainml_types;
+    sustainml_types.reserve(common::Topics::MAX);
+
+    sustainml_types.push_back(static_cast<TypeSupport>(new NodeStatusImplPubSubType()));
+    sustainml_types.push_back(static_cast<TypeSupport>(new NodeControlImplPubSubType()));
+    sustainml_types.push_back(static_cast<TypeSupport>(new UserInputImplPubSubType()));
+    sustainml_types.push_back(static_cast<TypeSupport>(new EncodedTaskImplPubSubType()));
+    sustainml_types.push_back(static_cast<TypeSupport>(new MLModelImplPubSubType()));
+    sustainml_types.push_back(static_cast<TypeSupport>(new HWResourceImplPubSubType()));
+    sustainml_types.push_back(static_cast<TypeSupport>(new CO2FootprintImplPubSubType()));
+
+    for (auto&& type : sustainml_types)
     {
-        if (!writers_.empty())
-        {
-            writers_[STATUS_WRITER_IDX]->write(&node_status_);
-        }
+        participant_->register_type(type);
     }
 
-    void NodeImpl::terminate()
+    //! Initialize common topics
+    initialize_subscription(common::TopicCollection::get()[common::Topics::NODE_CONTROL].first.c_str(),
+            common::TopicCollection::get()[common::Topics::NODE_CONTROL].second.c_str(),
+            &control_listener_, opts);
+
+    initialize_publication(common::TopicCollection::get()[common::Topics::NODE_STATUS].first.c_str(),
+            common::TopicCollection::get()[common::Topics::NODE_STATUS].second.c_str(),
+            opts);
+
+    //! Initialize node
+    node_status_.node_name(name);
+    node_status_.node_status(::NODE_INITIALIZING);
+
+    publish_node_status();
+
+    return true;
+}
+
+void NodeImpl::spin()
+{
+    EPROSIMA_LOG_INFO(NODE, "Spinning Node... ");
+
+    node_status_.node_status(::NODE_IDLE);
+    publish_node_status();
+
+    std::unique_lock<std::mutex> lock(spin_mtx_);
+    spin_cv_.wait(lock, [&]
+            {
+                return terminate_.load();
+            });
+}
+
+bool NodeImpl::initialize_subscription(
+        const char* topic_name,
+        const char* type_name,
+        eprosima::fastdds::dds::DataReaderListener* listener,
+        const Options& opts)
+{
+    Topic* topic = participant_->create_topic(topic_name, type_name, TOPIC_QOS_DEFAULT);
+
+    if (topic == nullptr)
     {
-        terminate_.store(true);
-        spin_cv_.notify_all();
+        return false;
     }
 
-    NodeImpl::NodeControlListener::NodeControlListener(NodeImpl *node)
-        : node_(node)
+    DataReader* reader = subscriber_->create_datareader(topic, opts.rqos, listener);
+
+    if (reader == nullptr)
     {
-
+        return false;
     }
 
-    NodeImpl::NodeControlListener::~NodeControlListener()
+    topics_.emplace_back(topic);
+    readers_.emplace_back(reader);
+
+    return true;
+}
+
+bool NodeImpl::initialize_publication(
+        const char* topic_name,
+        const char* type_name,
+        const Options& opts)
+{
+    Topic* topic = participant_->create_topic(topic_name, type_name, TOPIC_QOS_DEFAULT);
+
+    if (topic == nullptr)
     {
-
+        return false;
     }
 
-    void NodeImpl::NodeControlListener::on_subscription_matched(
+    DataWriter* writer = publisher_->create_datawriter(topic, opts.wqos);
+
+    if (writer == nullptr)
+    {
+        return false;
+    }
+
+    topics_.emplace_back(topic);
+    writers_.emplace_back(writer);
+
+    return true;
+}
+
+void NodeImpl::publish_node_status()
+{
+    if (!writers_.empty())
+    {
+        writers_[STATUS_WRITER_IDX]->write(&node_status_);
+    }
+}
+
+void NodeImpl::terminate()
+{
+    terminate_.store(true);
+    spin_cv_.notify_all();
+}
+
+NodeImpl::NodeControlListener::NodeControlListener(
+        NodeImpl* node)
+    : node_(node)
+{
+
+}
+
+NodeImpl::NodeControlListener::~NodeControlListener()
+{
+
+}
+
+void NodeImpl::NodeControlListener::on_subscription_matched(
         eprosima::fastdds::dds::DataReader* reader,
-        const eprosima::fastdds::dds::SubscriptionMatchedStatus & status)
+        const eprosima::fastdds::dds::SubscriptionMatchedStatus& status)
+{
+
+    EPROSIMA_LOG_INFO(NODE, "NodeControl Reader Suscription status");
+
+    // New remote DataWriter discovered
+    if (status.current_count_change == 1)
     {
-
-        EPROSIMA_LOG_INFO(NODE, "NodeControl Reader Suscription status");
-
-        // New remote DataWriter discovered
-        if (status.current_count_change == 1)
-        {
-            matched_ = status.current_count;
-            EPROSIMA_LOG_INFO(NODE, "Subscriber matched.");
-        }
-        // New remote DataWriter undiscovered
-        else if (status.current_count_change == -1)
-        {
-            matched_ = status.current_count;
-            EPROSIMA_LOG_INFO(NODE, "Subscriber unmatched.");
-        }
-        // Non-valid option
-        else
-        {
-            EPROSIMA_LOG_INFO(NODE, status.current_count_change
-                    << " is not a valid value for SubscriptionMatchedStatus current count change");
-        }
+        matched_ = status.current_count;
+        EPROSIMA_LOG_INFO(NODE, "Subscriber matched.");
     }
+    // New remote DataWriter undiscovered
+    else if (status.current_count_change == -1)
+    {
+        matched_ = status.current_count;
+        EPROSIMA_LOG_INFO(NODE, "Subscriber unmatched.");
+    }
+    // Non-valid option
+    else
+    {
+        EPROSIMA_LOG_INFO(NODE, status.current_count_change
+                << " is not a valid value for SubscriptionMatchedStatus current count change");
+    }
+}
 
-    void NodeImpl::NodeControlListener::on_data_available(
+void NodeImpl::NodeControlListener::on_data_available(
         eprosima::fastdds::dds::DataReader* reader)
-    {
-        EPROSIMA_LOG_INFO(NODE, "NodeStatus has a new status ");
-    }
+{
+    EPROSIMA_LOG_INFO(NODE, "NodeStatus has a new status ");
+}
 
 } // namespace core
 } // namespace sustainml

--- a/sustainml_cpp/src/cpp/nodes/CarbonFootprintNode.cpp
+++ b/sustainml_cpp/src/cpp/nodes/CarbonFootprintNode.cpp
@@ -38,6 +38,10 @@ namespace co2_tracker_module {
         sustainml::core::Options opts;
         opts.rqos.resource_limits().max_instances = 500;
         opts.rqos.resource_limits().max_samples_per_instance = 1;
+        opts.rqos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+        opts.rqos.history().kind = eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS;
+        opts.rqos.history().depth = 1;
+
         opts.wqos.resource_limits().max_instances = 500;
         opts.wqos.resource_limits().max_samples_per_instance = 1;
 

--- a/sustainml_cpp/src/cpp/nodes/CarbonFootprintNode.cpp
+++ b/sustainml_cpp/src/cpp/nodes/CarbonFootprintNode.cpp
@@ -68,6 +68,8 @@ namespace co2_tracker_module {
         listener_hw_queue_.reset(new core::QueuedNodeListener<HWResource>(this));
         listener_user_input_queue_.reset(new core::QueuedNodeListener<UserInput>(this));
 
+        task_data_pool_.reset(new utils::SamplePool<std::pair<NodeStatus, CO2Footprint>>(opts));
+
         initialize_subscription(sustainml::common::TopicCollection::get()[common::ML_MODEL].first.c_str(),
                                 sustainml::common::TopicCollection::get()[common::ML_MODEL].second.c_str(),
                                 &(*listener_ml_model_queue_), opts);
@@ -85,12 +87,12 @@ namespace co2_tracker_module {
                                opts);
     }
 
-    void CarbonFootprintNode::publish_to_user(const std::vector<std::pair<int,void*>> input_samples)
+    void CarbonFootprintNode::publish_to_user(const int& task_id, const std::vector<std::pair<int,void*>> input_samples)
     {
         //! Expected inputs are the number of reader minus the control reader
         if (input_samples.size() == ExpectedInputSamples::MAX)
         {
-            auto& user_listener_args = user_listener_.get_user_cb_args();
+            auto& user_listener_args = user_listener_.create_and_get_user_cb_args(task_id);
 
             size_t samples_retrieved{0};
             common::pair_queue_id_with_sample_type(
@@ -99,29 +101,18 @@ namespace co2_tracker_module {
                     ExpectedInputSamples::MAX,
                     samples_retrieved);
 
-            int task_id{-1};
-            auto first_sample_ptr = std::get<USER_INPUT_SAMPLE>(user_listener_args);
-
-            if (nullptr != first_sample_ptr)
-            {
-                task_id = first_sample_ptr->task_id();
-            }
-
-            if (task_id == common::INVALID_ID)
-            {
-                EPROSIMA_LOG_ERROR(CO2_NODE, "Error Retrieving the task_id of a sample");
-                return;
-            }
+            std::pair<NodeStatus, CO2Footprint>* task_data_cache;
 
             {
-                std::unique_lock<std::mutex> lock (mtx_);
-                task_data_.insert({task_id, {NodeStatus(), CO2Footprint()}});
+                std::lock_guard<std::mutex> lock (mtx_);
 
                 auto& status = std::get<TASK_STATUS_DATA>(user_listener_args);
                 auto& output = std::get<TASK_OUTPUT_DATA>(user_listener_args);
 
-                status = &task_data_[task_id].first;
-                output = &task_data_[task_id].second;
+                task_data_cache = task_data_pool_->get_new_cache_nts();
+
+                status = &task_data_cache->first;
+                output = &task_data_cache->second;
             }
 
             //! TODO: Manage task statuses individually
@@ -132,12 +123,12 @@ namespace co2_tracker_module {
                 publish_node_status();
             }
 
-            user_listener_.invoke_user_cb(core::helper::gen_seq<CarbonFootprintCallable::size>{});
+            user_listener_.invoke_user_cb(task_id, core::helper::gen_seq<CarbonFootprintCallable::size>{});
 
             //! Ensure task_id is forwarded to the output
-            task_data_[task_id].second.task_id(task_id);
+            task_data_cache->second.task_id(task_id);
 
-            writers()[OUTPUT_WRITER_IDX]->write(task_data_[task_id].second.get_impl());
+            writers()[OUTPUT_WRITER_IDX]->write(task_data_cache->second.get_impl());
 
             listener_ml_model_queue_->remove_element_by_taskid(task_id);
             listener_hw_queue_->remove_element_by_taskid(task_id);
@@ -145,7 +136,8 @@ namespace co2_tracker_module {
 
             {
                 std::unique_lock<std::mutex> lock (mtx_);
-                task_data_.erase(task_id);
+                task_data_pool_->release_cache_nts(task_data_cache);
+                user_listener_.remove_task_args(task_id);
             }
         }
         else

--- a/sustainml_cpp/src/cpp/nodes/CarbonFootprintNode.cpp
+++ b/sustainml_cpp/src/cpp/nodes/CarbonFootprintNode.cpp
@@ -30,121 +30,124 @@ using namespace types;
 namespace sustainml {
 namespace co2_tracker_module {
 
-    CarbonFootprintNode::CarbonFootprintNode(
-            CarbonFootprintTaskListener& user_listener)
-            : Node(common::CO2_TRACKER_NODE)
-            , user_listener_(user_listener)
+CarbonFootprintNode::CarbonFootprintNode(
+        CarbonFootprintTaskListener& user_listener)
+    : Node(common::CO2_TRACKER_NODE)
+    , user_listener_(user_listener)
+{
+    sustainml::core::Options opts;
+    opts.rqos.resource_limits().max_instances = 500;
+    opts.rqos.resource_limits().max_samples_per_instance = 1;
+    opts.rqos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+    opts.rqos.history().kind = eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS;
+    opts.rqos.history().depth = 1;
+
+    opts.wqos.resource_limits().max_instances = 500;
+    opts.wqos.resource_limits().max_samples_per_instance = 1;
+
+    init(opts);
+}
+
+CarbonFootprintNode::CarbonFootprintNode(
+        CarbonFootprintTaskListener& user_listener,
+        sustainml::core::Options opts)
+    : Node(common::CO2_TRACKER_NODE, opts)
+    , user_listener_(user_listener)
+{
+    init(opts);
+}
+
+CarbonFootprintNode::~CarbonFootprintNode()
+{
+
+}
+
+void CarbonFootprintNode::init (
+        const sustainml::core::Options& opts)
+{
+    listener_ml_model_queue_.reset(new core::QueuedNodeListener<MLModel>(this));
+    listener_hw_queue_.reset(new core::QueuedNodeListener<HWResource>(this));
+    listener_user_input_queue_.reset(new core::QueuedNodeListener<UserInput>(this));
+
+    task_data_pool_.reset(new utils::SamplePool<std::pair<NodeStatus, CO2Footprint>>(opts));
+
+    initialize_subscription(sustainml::common::TopicCollection::get()[common::ML_MODEL].first.c_str(),
+            sustainml::common::TopicCollection::get()[common::ML_MODEL].second.c_str(),
+            &(*listener_ml_model_queue_), opts);
+
+    initialize_subscription(sustainml::common::TopicCollection::get()[common::HW_RESOURCE].first.c_str(),
+            sustainml::common::TopicCollection::get()[common::HW_RESOURCE].second.c_str(),
+            &(*listener_hw_queue_), opts);
+
+    initialize_subscription(sustainml::common::TopicCollection::get()[common::USER_INPUT].first.c_str(),
+            sustainml::common::TopicCollection::get()[common::USER_INPUT].second.c_str(),
+            &(*listener_user_input_queue_), opts);
+
+    initialize_publication(sustainml::common::TopicCollection::get()[common::CO2_FOOTPRINT].first.c_str(),
+            sustainml::common::TopicCollection::get()[common::CO2_FOOTPRINT].second.c_str(),
+            opts);
+}
+
+void CarbonFootprintNode::publish_to_user(
+        const int& task_id,
+        const std::vector<std::pair<int, void*>> input_samples)
+{
+    //! Expected inputs are the number of reader minus the control reader
+    if (input_samples.size() == ExpectedInputSamples::MAX)
     {
-        sustainml::core::Options opts;
-        opts.rqos.resource_limits().max_instances = 500;
-        opts.rqos.resource_limits().max_samples_per_instance = 1;
-        opts.rqos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
-        opts.rqos.history().kind = eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS;
-        opts.rqos.history().depth = 1;
+        auto& user_listener_args = user_listener_.create_and_get_user_cb_args(task_id);
 
-        opts.wqos.resource_limits().max_instances = 500;
-        opts.wqos.resource_limits().max_samples_per_instance = 1;
+        size_t samples_retrieved{0};
+        common::pair_queue_id_with_sample_type(
+            input_samples,
+            user_listener_args,
+            ExpectedInputSamples::MAX,
+            samples_retrieved);
 
-        init(opts);
-    }
+        std::pair<NodeStatus, CO2Footprint>* task_data_cache;
 
-    CarbonFootprintNode::CarbonFootprintNode(
-            CarbonFootprintTaskListener& user_listener,
-            sustainml::core::Options opts)
-        : Node(common::CO2_TRACKER_NODE, opts)
-        , user_listener_(user_listener)
-    {
-        init(opts);
-    }
-
-    CarbonFootprintNode::~CarbonFootprintNode()
-    {
-
-    }
-
-    void CarbonFootprintNode::init (const sustainml::core::Options& opts)
-    {
-        listener_ml_model_queue_.reset(new core::QueuedNodeListener<MLModel>(this));
-        listener_hw_queue_.reset(new core::QueuedNodeListener<HWResource>(this));
-        listener_user_input_queue_.reset(new core::QueuedNodeListener<UserInput>(this));
-
-        task_data_pool_.reset(new utils::SamplePool<std::pair<NodeStatus, CO2Footprint>>(opts));
-
-        initialize_subscription(sustainml::common::TopicCollection::get()[common::ML_MODEL].first.c_str(),
-                                sustainml::common::TopicCollection::get()[common::ML_MODEL].second.c_str(),
-                                &(*listener_ml_model_queue_), opts);
-
-        initialize_subscription(sustainml::common::TopicCollection::get()[common::HW_RESOURCE].first.c_str(),
-                                sustainml::common::TopicCollection::get()[common::HW_RESOURCE].second.c_str(),
-                                &(*listener_hw_queue_), opts);
-
-        initialize_subscription(sustainml::common::TopicCollection::get()[common::USER_INPUT].first.c_str(),
-                                sustainml::common::TopicCollection::get()[common::USER_INPUT].second.c_str(),
-                                &(*listener_user_input_queue_), opts);
-
-        initialize_publication(sustainml::common::TopicCollection::get()[common::CO2_FOOTPRINT].first.c_str(),
-                               sustainml::common::TopicCollection::get()[common::CO2_FOOTPRINT].second.c_str(),
-                               opts);
-    }
-
-    void CarbonFootprintNode::publish_to_user(const int& task_id, const std::vector<std::pair<int,void*>> input_samples)
-    {
-        //! Expected inputs are the number of reader minus the control reader
-        if (input_samples.size() == ExpectedInputSamples::MAX)
         {
-            auto& user_listener_args = user_listener_.create_and_get_user_cb_args(task_id);
+            std::lock_guard<std::mutex> lock (mtx_);
 
-            size_t samples_retrieved{0};
-            common::pair_queue_id_with_sample_type(
-                    input_samples,
-                    user_listener_args,
-                    ExpectedInputSamples::MAX,
-                    samples_retrieved);
+            auto& status = std::get<TASK_STATUS_DATA>(user_listener_args);
+            auto& output = std::get<TASK_OUTPUT_DATA>(user_listener_args);
 
-            std::pair<NodeStatus, CO2Footprint>* task_data_cache;
+            task_data_cache = task_data_pool_->get_new_cache_nts();
 
-            {
-                std::lock_guard<std::mutex> lock (mtx_);
-
-                auto& status = std::get<TASK_STATUS_DATA>(user_listener_args);
-                auto& output = std::get<TASK_OUTPUT_DATA>(user_listener_args);
-
-                task_data_cache = task_data_pool_->get_new_cache_nts();
-
-                status = &task_data_cache->first;
-                output = &task_data_cache->second;
-            }
-
-            //! TODO: Manage task statuses individually
-
-            if (status() != NODE_RUNNING)
-            {
-                status(NODE_RUNNING);
-                publish_node_status();
-            }
-
-            user_listener_.invoke_user_cb(task_id, core::helper::gen_seq<CarbonFootprintCallable::size>{});
-
-            //! Ensure task_id is forwarded to the output
-            task_data_cache->second.task_id(task_id);
-
-            writers()[OUTPUT_WRITER_IDX]->write(task_data_cache->second.get_impl());
-
-            listener_ml_model_queue_->remove_element_by_taskid(task_id);
-            listener_hw_queue_->remove_element_by_taskid(task_id);
-            listener_user_input_queue_->remove_element_by_taskid(task_id);
-
-            {
-                std::unique_lock<std::mutex> lock (mtx_);
-                task_data_pool_->release_cache_nts(task_data_cache);
-                user_listener_.remove_task_args(task_id);
-            }
+            status = &task_data_cache->first;
+            output = &task_data_cache->second;
         }
-        else
+
+        //! TODO: Manage task statuses individually
+
+        if (status() != NODE_RUNNING)
         {
-            EPROSIMA_LOG_ERROR(CO2_NODE, "Input size mismatch");
+            status(NODE_RUNNING);
+            publish_node_status();
+        }
+
+        user_listener_.invoke_user_cb(task_id, core::helper::gen_seq<CarbonFootprintCallable::size>{});
+
+        //! Ensure task_id is forwarded to the output
+        task_data_cache->second.task_id(task_id);
+
+        writers()[OUTPUT_WRITER_IDX]->write(task_data_cache->second.get_impl());
+
+        listener_ml_model_queue_->remove_element_by_taskid(task_id);
+        listener_hw_queue_->remove_element_by_taskid(task_id);
+        listener_user_input_queue_->remove_element_by_taskid(task_id);
+
+        {
+            std::unique_lock<std::mutex> lock (mtx_);
+            task_data_pool_->release_cache_nts(task_data_cache);
+            user_listener_.remove_task_args(task_id);
         }
     }
+    else
+    {
+        EPROSIMA_LOG_ERROR(CO2_NODE, "Input size mismatch");
+    }
+}
 
 } // co2_tracker_module
 } // sustainml

--- a/sustainml_cpp/src/cpp/nodes/HardwareResourcesNode.cpp
+++ b/sustainml_cpp/src/cpp/nodes/HardwareResourcesNode.cpp
@@ -38,6 +38,10 @@ namespace hardware_module {
         sustainml::core::Options opts;
         opts.rqos.resource_limits().max_instances = 500;
         opts.rqos.resource_limits().max_samples_per_instance = 1;
+        opts.rqos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+        opts.rqos.history().kind = eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS;
+        opts.rqos.history().depth = 1;
+
         opts.wqos.resource_limits().max_instances = 500;
         opts.wqos.resource_limits().max_samples_per_instance = 1;
 

--- a/sustainml_cpp/src/cpp/nodes/HardwareResourcesNode.cpp
+++ b/sustainml_cpp/src/cpp/nodes/HardwareResourcesNode.cpp
@@ -66,6 +66,8 @@ namespace hardware_module {
     {
         listener_ml_model_queue_.reset(new core::QueuedNodeListener<MLModel>(this));
 
+        task_data_pool_.reset(new utils::SamplePool<std::pair<NodeStatus, HWResource>>(opts));
+
         initialize_subscription(sustainml::common::TopicCollection::get()[common::ML_MODEL].first.c_str(),
                                 sustainml::common::TopicCollection::get()[common::ML_MODEL].second.c_str(),
                                 &(*listener_ml_model_queue_), opts);
@@ -75,12 +77,12 @@ namespace hardware_module {
                                opts);
     }
 
-    void HardwareResourcesNode::publish_to_user(const std::vector<std::pair<int,void*>> input_samples)
+    void HardwareResourcesNode::publish_to_user(const int& task_id, const std::vector<std::pair<int,void*>> input_samples)
     {
         //! Expected inputs are the number of reader minus the control reader
         if (input_samples.size() == ExpectedInputSamples::MAX)
         {
-            auto& user_listener_args = user_listener_.get_user_cb_args();
+            auto& user_listener_args = user_listener_.create_and_get_user_cb_args(task_id);
 
             size_t samples_retrieved{0};
             common::pair_queue_id_with_sample_type(
@@ -89,29 +91,18 @@ namespace hardware_module {
                     ExpectedInputSamples::MAX,
                     samples_retrieved);
 
-            int task_id{-1};
-            auto first_sample_ptr = std::get<ML_MODEL_SAMPLE>(user_listener_args);
-
-            if (nullptr != first_sample_ptr)
-            {
-                task_id = first_sample_ptr->task_id();
-            }
-
-            if (task_id == common::INVALID_ID)
-            {
-                EPROSIMA_LOG_ERROR(HW_NODE, "Error Retrieving the task_id of a sample");
-                return;
-            }
+            std::pair<NodeStatus, HWResource>* task_data_cache;
 
             {
-                std::unique_lock<std::mutex> lock (mtx_);
-                task_data_.insert({task_id, {NodeStatus(), HWResource()}});
+                std::lock_guard<std::mutex> lock (mtx_);
 
                 auto& status = std::get<TASK_STATUS_DATA>(user_listener_args);
                 auto& output = std::get<TASK_OUTPUT_DATA>(user_listener_args);
 
-                status = &task_data_[task_id].first;
-                output = &task_data_[task_id].second;
+                task_data_cache = task_data_pool_->get_new_cache_nts();
+
+                status = &task_data_cache->first;
+                output = &task_data_cache->second;
             }
 
             //! TODO: Manage task statuses individually
@@ -122,18 +113,19 @@ namespace hardware_module {
                 publish_node_status();
             }
 
-            user_listener_.invoke_user_cb(core::helper::gen_seq<HardwareResourcesCallable::size>{});
+            user_listener_.invoke_user_cb(task_id, core::helper::gen_seq<HardwareResourcesCallable::size>{});
 
             //! Ensure task_id is forwarded to the output
-            task_data_[task_id].second.task_id(task_id);
+            task_data_cache->second.task_id(task_id);
 
-            writers()[OUTPUT_WRITER_IDX]->write(task_data_[task_id].second.get_impl());
+            writers()[OUTPUT_WRITER_IDX]->write(task_data_cache->second.get_impl());
 
             listener_ml_model_queue_->remove_element_by_taskid(task_id);
 
             {
-                std::unique_lock<std::mutex> lock (mtx_);
-                task_data_.erase(task_id);
+                std::lock_guard<std::mutex> lock (mtx_);
+                task_data_pool_->release_cache_nts(task_data_cache);
+                user_listener_.remove_task_args(task_id);
             }
         }
         else

--- a/sustainml_cpp/src/cpp/nodes/HardwareResourcesNode.cpp
+++ b/sustainml_cpp/src/cpp/nodes/HardwareResourcesNode.cpp
@@ -30,109 +30,112 @@ using namespace types;
 namespace sustainml {
 namespace hardware_module {
 
-    HardwareResourcesNode::HardwareResourcesNode(
-            HardwareResourcesTaskListener& user_listener)
-            : Node(common::HW_RESOURCES_NODE)
-            , user_listener_(user_listener)
+HardwareResourcesNode::HardwareResourcesNode(
+        HardwareResourcesTaskListener& user_listener)
+    : Node(common::HW_RESOURCES_NODE)
+    , user_listener_(user_listener)
+{
+    sustainml::core::Options opts;
+    opts.rqos.resource_limits().max_instances = 500;
+    opts.rqos.resource_limits().max_samples_per_instance = 1;
+    opts.rqos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+    opts.rqos.history().kind = eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS;
+    opts.rqos.history().depth = 1;
+
+    opts.wqos.resource_limits().max_instances = 500;
+    opts.wqos.resource_limits().max_samples_per_instance = 1;
+
+    init(opts);
+}
+
+HardwareResourcesNode::HardwareResourcesNode(
+        HardwareResourcesTaskListener& user_listener,
+        sustainml::core::Options opts)
+    : Node(common::HW_RESOURCES_NODE, opts)
+    , user_listener_(user_listener)
+{
+    init(opts);
+}
+
+HardwareResourcesNode::~HardwareResourcesNode()
+{
+
+}
+
+void HardwareResourcesNode::init (
+        const sustainml::core::Options& opts)
+{
+    listener_ml_model_queue_.reset(new core::QueuedNodeListener<MLModel>(this));
+
+    task_data_pool_.reset(new utils::SamplePool<std::pair<NodeStatus, HWResource>>(opts));
+
+    initialize_subscription(sustainml::common::TopicCollection::get()[common::ML_MODEL].first.c_str(),
+            sustainml::common::TopicCollection::get()[common::ML_MODEL].second.c_str(),
+            &(*listener_ml_model_queue_), opts);
+
+    initialize_publication(sustainml::common::TopicCollection::get()[common::HW_RESOURCE].first.c_str(),
+            sustainml::common::TopicCollection::get()[common::HW_RESOURCE].second.c_str(),
+            opts);
+}
+
+void HardwareResourcesNode::publish_to_user(
+        const int& task_id,
+        const std::vector<std::pair<int, void*>> input_samples)
+{
+    //! Expected inputs are the number of reader minus the control reader
+    if (input_samples.size() == ExpectedInputSamples::MAX)
     {
-        sustainml::core::Options opts;
-        opts.rqos.resource_limits().max_instances = 500;
-        opts.rqos.resource_limits().max_samples_per_instance = 1;
-        opts.rqos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
-        opts.rqos.history().kind = eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS;
-        opts.rqos.history().depth = 1;
+        auto& user_listener_args = user_listener_.create_and_get_user_cb_args(task_id);
 
-        opts.wqos.resource_limits().max_instances = 500;
-        opts.wqos.resource_limits().max_samples_per_instance = 1;
+        size_t samples_retrieved{0};
+        common::pair_queue_id_with_sample_type(
+            input_samples,
+            user_listener_args,
+            ExpectedInputSamples::MAX,
+            samples_retrieved);
 
-        init(opts);
-    }
+        std::pair<NodeStatus, HWResource>* task_data_cache;
 
-    HardwareResourcesNode::HardwareResourcesNode(
-            HardwareResourcesTaskListener& user_listener,
-            sustainml::core::Options opts)
-            : Node(common::HW_RESOURCES_NODE, opts)
-            , user_listener_(user_listener)
-    {
-        init(opts);
-    }
-
-    HardwareResourcesNode::~HardwareResourcesNode()
-    {
-
-    }
-
-    void HardwareResourcesNode::init (const sustainml::core::Options& opts)
-    {
-        listener_ml_model_queue_.reset(new core::QueuedNodeListener<MLModel>(this));
-
-        task_data_pool_.reset(new utils::SamplePool<std::pair<NodeStatus, HWResource>>(opts));
-
-        initialize_subscription(sustainml::common::TopicCollection::get()[common::ML_MODEL].first.c_str(),
-                                sustainml::common::TopicCollection::get()[common::ML_MODEL].second.c_str(),
-                                &(*listener_ml_model_queue_), opts);
-
-        initialize_publication(sustainml::common::TopicCollection::get()[common::HW_RESOURCE].first.c_str(),
-                               sustainml::common::TopicCollection::get()[common::HW_RESOURCE].second.c_str(),
-                               opts);
-    }
-
-    void HardwareResourcesNode::publish_to_user(const int& task_id, const std::vector<std::pair<int,void*>> input_samples)
-    {
-        //! Expected inputs are the number of reader minus the control reader
-        if (input_samples.size() == ExpectedInputSamples::MAX)
         {
-            auto& user_listener_args = user_listener_.create_and_get_user_cb_args(task_id);
+            std::lock_guard<std::mutex> lock (mtx_);
 
-            size_t samples_retrieved{0};
-            common::pair_queue_id_with_sample_type(
-                    input_samples,
-                    user_listener_args,
-                    ExpectedInputSamples::MAX,
-                    samples_retrieved);
+            auto& status = std::get<TASK_STATUS_DATA>(user_listener_args);
+            auto& output = std::get<TASK_OUTPUT_DATA>(user_listener_args);
 
-            std::pair<NodeStatus, HWResource>* task_data_cache;
+            task_data_cache = task_data_pool_->get_new_cache_nts();
 
-            {
-                std::lock_guard<std::mutex> lock (mtx_);
-
-                auto& status = std::get<TASK_STATUS_DATA>(user_listener_args);
-                auto& output = std::get<TASK_OUTPUT_DATA>(user_listener_args);
-
-                task_data_cache = task_data_pool_->get_new_cache_nts();
-
-                status = &task_data_cache->first;
-                output = &task_data_cache->second;
-            }
-
-            //! TODO: Manage task statuses individually
-
-            if (status() != NODE_RUNNING)
-            {
-                status(NODE_RUNNING);
-                publish_node_status();
-            }
-
-            user_listener_.invoke_user_cb(task_id, core::helper::gen_seq<HardwareResourcesCallable::size>{});
-
-            //! Ensure task_id is forwarded to the output
-            task_data_cache->second.task_id(task_id);
-
-            writers()[OUTPUT_WRITER_IDX]->write(task_data_cache->second.get_impl());
-
-            listener_ml_model_queue_->remove_element_by_taskid(task_id);
-
-            {
-                std::lock_guard<std::mutex> lock (mtx_);
-                task_data_pool_->release_cache_nts(task_data_cache);
-                user_listener_.remove_task_args(task_id);
-            }
+            status = &task_data_cache->first;
+            output = &task_data_cache->second;
         }
-        else
+
+        //! TODO: Manage task statuses individually
+
+        if (status() != NODE_RUNNING)
         {
-            EPROSIMA_LOG_ERROR(HW_NODE, "Input size mismatch");
+            status(NODE_RUNNING);
+            publish_node_status();
+        }
+
+        user_listener_.invoke_user_cb(task_id, core::helper::gen_seq<HardwareResourcesCallable::size>{});
+
+        //! Ensure task_id is forwarded to the output
+        task_data_cache->second.task_id(task_id);
+
+        writers()[OUTPUT_WRITER_IDX]->write(task_data_cache->second.get_impl());
+
+        listener_ml_model_queue_->remove_element_by_taskid(task_id);
+
+        {
+            std::lock_guard<std::mutex> lock (mtx_);
+            task_data_pool_->release_cache_nts(task_data_cache);
+            user_listener_.remove_task_args(task_id);
         }
     }
+    else
+    {
+        EPROSIMA_LOG_ERROR(HW_NODE, "Input size mismatch");
+    }
+}
 
 } // hardware_module
 } // sustainml

--- a/sustainml_cpp/src/cpp/nodes/MLModelNode.cpp
+++ b/sustainml_cpp/src/cpp/nodes/MLModelNode.cpp
@@ -38,6 +38,10 @@ namespace ml_model_provider_module {
         sustainml::core::Options opts;
         opts.rqos.resource_limits().max_instances = 500;
         opts.rqos.resource_limits().max_samples_per_instance = 1;
+        opts.rqos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+        opts.rqos.history().kind = eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS;
+        opts.rqos.history().depth = 1;
+
         opts.wqos.resource_limits().max_instances = 500;
         opts.wqos.resource_limits().max_samples_per_instance = 1;
 

--- a/sustainml_cpp/src/cpp/nodes/MLModelNode.cpp
+++ b/sustainml_cpp/src/cpp/nodes/MLModelNode.cpp
@@ -30,110 +30,112 @@ using namespace types;
 namespace sustainml {
 namespace ml_model_provider_module {
 
-    MLModelNode::MLModelNode(
-            MLModelTaskListener& user_listener)
-            : Node(common::ML_MODEL_NODE)
-            , user_listener_(user_listener)
+MLModelNode::MLModelNode(
+        MLModelTaskListener& user_listener)
+    : Node(common::ML_MODEL_NODE)
+    , user_listener_(user_listener)
+{
+    sustainml::core::Options opts;
+    opts.rqos.resource_limits().max_instances = 500;
+    opts.rqos.resource_limits().max_samples_per_instance = 1;
+    opts.rqos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+    opts.rqos.history().kind = eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS;
+    opts.rqos.history().depth = 1;
+
+    opts.wqos.resource_limits().max_instances = 500;
+    opts.wqos.resource_limits().max_samples_per_instance = 1;
+
+    init(opts);
+}
+
+MLModelNode::MLModelNode(
+        MLModelTaskListener& user_listener,
+        sustainml::core::Options opts)
+    : Node(common::ML_MODEL_NODE, opts)
+    , user_listener_(user_listener)
+{
+    init(opts);
+}
+
+MLModelNode::~MLModelNode()
+{
+
+}
+
+void MLModelNode::init (
+        const sustainml::core::Options& opts)
+{
+    listener_enc_task_queue_.reset(new core::QueuedNodeListener<EncodedTask>(this));
+
+    task_data_pool_.reset(new utils::SamplePool<std::pair<NodeStatus, MLModel>>(opts));
+
+    initialize_subscription(sustainml::common::TopicCollection::get()[common::ENCODED_TASK].first.c_str(),
+            sustainml::common::TopicCollection::get()[common::ENCODED_TASK].second.c_str(),
+            &(*listener_enc_task_queue_), opts);
+
+    initialize_publication(sustainml::common::TopicCollection::get()[common::ML_MODEL].first.c_str(),
+            sustainml::common::TopicCollection::get()[common::ML_MODEL].second.c_str(),
+            opts);
+}
+
+void MLModelNode::publish_to_user(
+        const int& task_id,
+        const std::vector<std::pair<int, void*>> input_samples)
+{
+    //! Expected inputs are the number of reader minus the control reader
+    if (input_samples.size() == ExpectedInputSamples::MAX)
     {
-        sustainml::core::Options opts;
-        opts.rqos.resource_limits().max_instances = 500;
-        opts.rqos.resource_limits().max_samples_per_instance = 1;
-        opts.rqos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
-        opts.rqos.history().kind = eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS;
-        opts.rqos.history().depth = 1;
+        auto& user_listener_args = user_listener_.create_and_get_user_cb_args(task_id);
 
-        opts.wqos.resource_limits().max_instances = 500;
-        opts.wqos.resource_limits().max_samples_per_instance = 1;
+        size_t samples_retrieved{0};
+        common::pair_queue_id_with_sample_type(
+            input_samples,
+            user_listener_args,
+            ExpectedInputSamples::MAX,
+            samples_retrieved);
 
-        init(opts);
-    }
+        std::pair<NodeStatus, MLModel>* task_data_cache;
 
-
-    MLModelNode::MLModelNode(
-            MLModelTaskListener& user_listener,
-            sustainml::core::Options opts)
-            : Node(common::ML_MODEL_NODE, opts)
-            , user_listener_(user_listener)
-    {
-        init(opts);
-    }
-
-    MLModelNode::~MLModelNode()
-    {
-
-    }
-
-    void MLModelNode::init (const sustainml::core::Options& opts)
-    {
-        listener_enc_task_queue_.reset(new core::QueuedNodeListener<EncodedTask>(this));
-
-        task_data_pool_.reset(new utils::SamplePool<std::pair<NodeStatus, MLModel>>(opts));
-
-        initialize_subscription(sustainml::common::TopicCollection::get()[common::ENCODED_TASK].first.c_str(),
-                                sustainml::common::TopicCollection::get()[common::ENCODED_TASK].second.c_str(),
-                                &(*listener_enc_task_queue_), opts);
-
-        initialize_publication(sustainml::common::TopicCollection::get()[common::ML_MODEL].first.c_str(),
-                               sustainml::common::TopicCollection::get()[common::ML_MODEL].second.c_str(),
-                               opts);
-    }
-
-    void MLModelNode::publish_to_user(const int& task_id, const std::vector<std::pair<int,void*>> input_samples)
-    {
-        //! Expected inputs are the number of reader minus the control reader
-        if (input_samples.size() == ExpectedInputSamples::MAX)
         {
-            auto& user_listener_args = user_listener_.create_and_get_user_cb_args(task_id);
+            std::lock_guard<std::mutex> lock (mtx_);
 
-            size_t samples_retrieved{0};
-            common::pair_queue_id_with_sample_type(
-                    input_samples,
-                    user_listener_args,
-                    ExpectedInputSamples::MAX,
-                    samples_retrieved);
+            auto& status = std::get<TASK_STATUS_DATA>(user_listener_args);
+            auto& output = std::get<TASK_OUTPUT_DATA>(user_listener_args);
 
-            std::pair<NodeStatus, MLModel>* task_data_cache;
+            task_data_cache = task_data_pool_->get_new_cache_nts();
 
-            {
-                std::lock_guard<std::mutex> lock (mtx_);
-
-                auto& status = std::get<TASK_STATUS_DATA>(user_listener_args);
-                auto& output = std::get<TASK_OUTPUT_DATA>(user_listener_args);
-
-                task_data_cache = task_data_pool_->get_new_cache_nts();
-
-                status = &task_data_cache->first;
-                output = &task_data_cache->second;
-            }
-
-            //! TODO: Manage task statuses individually
-
-            if (status() != NODE_RUNNING)
-            {
-                status(NODE_RUNNING);
-                publish_node_status();
-            }
-
-            user_listener_.invoke_user_cb(task_id, core::helper::gen_seq<MLModelCallable::size>{});
-
-            //! Ensure task_id is forwarded to the output
-            task_data_cache->second.task_id(task_id);
-
-            writers()[OUTPUT_WRITER_IDX]->write(task_data_cache->second.get_impl());
-
-            listener_enc_task_queue_->remove_element_by_taskid(task_id);
-
-            {
-                std::lock_guard<std::mutex> lock (mtx_);
-                task_data_pool_->release_cache_nts(task_data_cache);
-                user_listener_.remove_task_args(task_id);
-            }
+            status = &task_data_cache->first;
+            output = &task_data_cache->second;
         }
-        else
+
+        //! TODO: Manage task statuses individually
+
+        if (status() != NODE_RUNNING)
         {
-            EPROSIMA_LOG_ERROR(MLMODEL_NODE, "Input size mismatch");
+            status(NODE_RUNNING);
+            publish_node_status();
+        }
+
+        user_listener_.invoke_user_cb(task_id, core::helper::gen_seq<MLModelCallable::size>{});
+
+        //! Ensure task_id is forwarded to the output
+        task_data_cache->second.task_id(task_id);
+
+        writers()[OUTPUT_WRITER_IDX]->write(task_data_cache->second.get_impl());
+
+        listener_enc_task_queue_->remove_element_by_taskid(task_id);
+
+        {
+            std::lock_guard<std::mutex> lock (mtx_);
+            task_data_pool_->release_cache_nts(task_data_cache);
+            user_listener_.remove_task_args(task_id);
         }
     }
+    else
+    {
+        EPROSIMA_LOG_ERROR(MLMODEL_NODE, "Input size mismatch");
+    }
+}
 
 } // ml_model_provider_module
 } // sustainml

--- a/sustainml_cpp/src/cpp/nodes/MLModelNode.cpp
+++ b/sustainml_cpp/src/cpp/nodes/MLModelNode.cpp
@@ -67,6 +67,8 @@ namespace ml_model_provider_module {
     {
         listener_enc_task_queue_.reset(new core::QueuedNodeListener<EncodedTask>(this));
 
+        task_data_pool_.reset(new utils::SamplePool<std::pair<NodeStatus, MLModel>>(opts));
+
         initialize_subscription(sustainml::common::TopicCollection::get()[common::ENCODED_TASK].first.c_str(),
                                 sustainml::common::TopicCollection::get()[common::ENCODED_TASK].second.c_str(),
                                 &(*listener_enc_task_queue_), opts);
@@ -76,12 +78,12 @@ namespace ml_model_provider_module {
                                opts);
     }
 
-    void MLModelNode::publish_to_user(const std::vector<std::pair<int,void*>> input_samples)
+    void MLModelNode::publish_to_user(const int& task_id, const std::vector<std::pair<int,void*>> input_samples)
     {
         //! Expected inputs are the number of reader minus the control reader
         if (input_samples.size() == ExpectedInputSamples::MAX)
         {
-            auto& user_listener_args = user_listener_.get_user_cb_args();
+            auto& user_listener_args = user_listener_.create_and_get_user_cb_args(task_id);
 
             size_t samples_retrieved{0};
             common::pair_queue_id_with_sample_type(
@@ -90,29 +92,18 @@ namespace ml_model_provider_module {
                     ExpectedInputSamples::MAX,
                     samples_retrieved);
 
-            int task_id{-1};
-            auto first_sample_ptr = std::get<ENCODED_TASK_SAMPLE>(user_listener_args);
-
-            if (nullptr != first_sample_ptr)
-            {
-                task_id = first_sample_ptr->task_id();
-            }
-
-            if (task_id == common::INVALID_ID)
-            {
-                EPROSIMA_LOG_ERROR(MLMODEL_NODE, "Error Retrieving the task_id of a sample");
-                return;
-            }
+            std::pair<NodeStatus, MLModel>* task_data_cache;
 
             {
-                std::unique_lock<std::mutex> lock (mtx_);
-                task_data_.insert({task_id, {NodeStatus(), MLModel()}});
+                std::lock_guard<std::mutex> lock (mtx_);
 
                 auto& status = std::get<TASK_STATUS_DATA>(user_listener_args);
                 auto& output = std::get<TASK_OUTPUT_DATA>(user_listener_args);
 
-                status = &task_data_[task_id].first;
-                output = &task_data_[task_id].second;
+                task_data_cache = task_data_pool_->get_new_cache_nts();
+
+                status = &task_data_cache->first;
+                output = &task_data_cache->second;
             }
 
             //! TODO: Manage task statuses individually
@@ -123,18 +114,19 @@ namespace ml_model_provider_module {
                 publish_node_status();
             }
 
-            user_listener_.invoke_user_cb(core::helper::gen_seq<MLModelCallable::size>{});
+            user_listener_.invoke_user_cb(task_id, core::helper::gen_seq<MLModelCallable::size>{});
 
             //! Ensure task_id is forwarded to the output
-            task_data_[task_id].second.task_id(task_id);
+            task_data_cache->second.task_id(task_id);
 
-            writers()[OUTPUT_WRITER_IDX]->write(task_data_[task_id].second.get_impl());
+            writers()[OUTPUT_WRITER_IDX]->write(task_data_cache->second.get_impl());
 
             listener_enc_task_queue_->remove_element_by_taskid(task_id);
 
             {
-                std::unique_lock<std::mutex> lock (mtx_);
-                task_data_.erase(task_id);
+                std::lock_guard<std::mutex> lock (mtx_);
+                task_data_pool_->release_cache_nts(task_data_cache);
+                user_listener_.remove_task_args(task_id);
             }
         }
         else

--- a/sustainml_cpp/src/cpp/nodes/TaskEncoderNode.cpp
+++ b/sustainml_cpp/src/cpp/nodes/TaskEncoderNode.cpp
@@ -30,109 +30,112 @@ using namespace types;
 namespace sustainml {
 namespace ml_task_encoding_module {
 
-    TaskEncoderNode::TaskEncoderNode(
-            TaskEncoderTaskListener& user_listener)
-            : Node(common::TASK_ENCODER_NODE)
-            , user_listener_(user_listener)
+TaskEncoderNode::TaskEncoderNode(
+        TaskEncoderTaskListener& user_listener)
+    : Node(common::TASK_ENCODER_NODE)
+    , user_listener_(user_listener)
+{
+    sustainml::core::Options opts;
+    opts.rqos.resource_limits().max_instances = 500;
+    opts.rqos.resource_limits().max_samples_per_instance = 1;
+    opts.rqos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+    opts.rqos.history().kind = eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS;
+    opts.rqos.history().depth = 1;
+
+    opts.wqos.resource_limits().max_instances = 500;
+    opts.wqos.resource_limits().max_samples_per_instance = 1;
+
+    init(opts);
+}
+
+TaskEncoderNode::TaskEncoderNode(
+        TaskEncoderTaskListener& user_listener,
+        sustainml::core::Options opts)
+    : Node(common::TASK_ENCODER_NODE, opts)
+    , user_listener_(user_listener)
+{
+    init(opts);
+}
+
+TaskEncoderNode::~TaskEncoderNode()
+{
+
+}
+
+void TaskEncoderNode::init (
+        const sustainml::core::Options& opts)
+{
+    listener_user_input_queue_.reset(new core::QueuedNodeListener<UserInput>(this));
+
+    task_data_pool_.reset(new utils::SamplePool<std::pair<NodeStatus, EncodedTask>>(opts));
+
+    initialize_subscription(sustainml::common::TopicCollection::get()[common::USER_INPUT].first.c_str(),
+            sustainml::common::TopicCollection::get()[common::USER_INPUT].second.c_str(),
+            &(*listener_user_input_queue_), opts);
+
+    initialize_publication(sustainml::common::TopicCollection::get()[common::ENCODED_TASK].first.c_str(),
+            sustainml::common::TopicCollection::get()[common::ENCODED_TASK].second.c_str(),
+            opts);
+}
+
+void TaskEncoderNode::publish_to_user(
+        const int& task_id,
+        const std::vector<std::pair<int, void*>> input_samples)
+{
+    //! Expected inputs are the number of reader minus the control reader
+    if (input_samples.size() == ExpectedInputSamples::MAX)
     {
-        sustainml::core::Options opts;
-        opts.rqos.resource_limits().max_instances = 500;
-        opts.rqos.resource_limits().max_samples_per_instance = 1;
-        opts.rqos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
-        opts.rqos.history().kind = eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS;
-        opts.rqos.history().depth = 1;
+        auto& user_listener_args = user_listener_.create_and_get_user_cb_args(task_id);
 
-        opts.wqos.resource_limits().max_instances = 500;
-        opts.wqos.resource_limits().max_samples_per_instance = 1;
+        size_t samples_retrieved{0};
+        common::pair_queue_id_with_sample_type(
+            input_samples,
+            user_listener_args,
+            ExpectedInputSamples::MAX,
+            samples_retrieved);
 
-        init(opts);
-    }
+        std::pair<NodeStatus, EncodedTask>* task_data_cache;
 
-    TaskEncoderNode::TaskEncoderNode(
-            TaskEncoderTaskListener& user_listener,
-            sustainml::core::Options opts)
-            : Node(common::TASK_ENCODER_NODE, opts)
-            , user_listener_(user_listener)
-    {
-        init(opts);
-    }
-
-    TaskEncoderNode::~TaskEncoderNode()
-    {
-
-    }
-
-    void TaskEncoderNode::init (const sustainml::core::Options& opts)
-    {
-        listener_user_input_queue_.reset(new core::QueuedNodeListener<UserInput>(this));
-
-        task_data_pool_.reset(new utils::SamplePool<std::pair<NodeStatus, EncodedTask>>(opts));
-
-        initialize_subscription(sustainml::common::TopicCollection::get()[common::USER_INPUT].first.c_str(),
-                                sustainml::common::TopicCollection::get()[common::USER_INPUT].second.c_str(),
-                                &(*listener_user_input_queue_), opts);
-
-        initialize_publication(sustainml::common::TopicCollection::get()[common::ENCODED_TASK].first.c_str(),
-                               sustainml::common::TopicCollection::get()[common::ENCODED_TASK].second.c_str(),
-                               opts);
-    }
-
-    void TaskEncoderNode::publish_to_user(const int& task_id, const std::vector<std::pair<int, void*>> input_samples)
-    {
-        //! Expected inputs are the number of reader minus the control reader
-        if (input_samples.size() == ExpectedInputSamples::MAX)
         {
-            auto& user_listener_args = user_listener_.create_and_get_user_cb_args(task_id);
+            std::lock_guard<std::mutex> lock (mtx_);
 
-            size_t samples_retrieved{0};
-            common::pair_queue_id_with_sample_type(
-                    input_samples,
-                    user_listener_args,
-                    ExpectedInputSamples::MAX,
-                    samples_retrieved);
+            auto& status = std::get<TASK_STATUS_DATA>(user_listener_args);
+            auto& output = std::get<TASK_OUTPUT_DATA>(user_listener_args);
 
-            std::pair<NodeStatus, EncodedTask>* task_data_cache;
+            task_data_cache = task_data_pool_->get_new_cache_nts();
 
-            {
-                std::lock_guard<std::mutex> lock (mtx_);
-
-                auto& status = std::get<TASK_STATUS_DATA>(user_listener_args);
-                auto& output = std::get<TASK_OUTPUT_DATA>(user_listener_args);
-
-                task_data_cache = task_data_pool_->get_new_cache_nts();
-
-                status = &task_data_cache->first;
-                output = &task_data_cache->second;
-            }
-
-            //! TODO: Manage task statuses individually
-
-            if (status() != NODE_RUNNING)
-            {
-                status(NODE_RUNNING);
-                publish_node_status();
-            }
-
-            user_listener_.invoke_user_cb(task_id, core::helper::gen_seq<TaskEncoderCallable::size>{});
-
-            //! Ensure task_id is forwarded to the output
-            task_data_cache->second.task_id(task_id);
-
-            writers()[OUTPUT_WRITER_IDX]->write(task_data_cache->second.get_impl());
-
-            listener_user_input_queue_->remove_element_by_taskid(task_id);
-
-            {
-                std::lock_guard<std::mutex> lock (mtx_);
-                task_data_pool_->release_cache_nts(task_data_cache);
-                user_listener_.remove_task_args(task_id);
-            }
+            status = &task_data_cache->first;
+            output = &task_data_cache->second;
         }
-        else
+
+        //! TODO: Manage task statuses individually
+
+        if (status() != NODE_RUNNING)
         {
-            EPROSIMA_LOG_ERROR(TASKENC_NODE, "Input size mismatch");
+            status(NODE_RUNNING);
+            publish_node_status();
+        }
+
+        user_listener_.invoke_user_cb(task_id, core::helper::gen_seq<TaskEncoderCallable::size>{});
+
+        //! Ensure task_id is forwarded to the output
+        task_data_cache->second.task_id(task_id);
+
+        writers()[OUTPUT_WRITER_IDX]->write(task_data_cache->second.get_impl());
+
+        listener_user_input_queue_->remove_element_by_taskid(task_id);
+
+        {
+            std::lock_guard<std::mutex> lock (mtx_);
+            task_data_pool_->release_cache_nts(task_data_cache);
+            user_listener_.remove_task_args(task_id);
         }
     }
+    else
+    {
+        EPROSIMA_LOG_ERROR(TASKENC_NODE, "Input size mismatch");
+    }
+}
 
 } // ml_task_encoding_module
 } // sustainml

--- a/sustainml_cpp/src/cpp/nodes/TaskEncoderNode.cpp
+++ b/sustainml_cpp/src/cpp/nodes/TaskEncoderNode.cpp
@@ -38,6 +38,10 @@ namespace ml_task_encoding_module {
         sustainml::core::Options opts;
         opts.rqos.resource_limits().max_instances = 500;
         opts.rqos.resource_limits().max_samples_per_instance = 1;
+        opts.rqos.reliability().kind = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+        opts.rqos.history().kind = eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS;
+        opts.rqos.history().depth = 1;
+
         opts.wqos.resource_limits().max_instances = 500;
         opts.wqos.resource_limits().max_samples_per_instance = 1;
 


### PR DESCRIPTION
This PR refactors the way user callbacks were invoked, by storing the tuple of args per `task_id` instead of shared one among all user callback invocations which could lead to inconsistences. It was detected while performing tests in #22 when nodes suddenly received the whole burst of past sample tasks.

In addition, reliability has been added to the endpoints.

Finally, the `task data [node status, output]` data has been changed to be stored in a SamplePool for better uniformity and performance.  