### PR TITLE
[198282] Set Application ID in nodes

### DIFF
--- a/sustainml_cpp/src/cpp/core/NodeImpl.cpp
+++ b/sustainml_cpp/src/cpp/core/NodeImpl.cpp
@@ -94,6 +94,11 @@ bool NodeImpl::init(
     //! Initialize entities
     DomainParticipantQos pqos = opts.pqos;
     pqos.name(name);
+
+    //! Set sustainML app ID participant properties
+    pqos.properties().properties().emplace_back("fastdds.application.id", "SUSTAINML", true);
+    pqos.properties().properties().emplace_back("fastdds.application.metadata", "", true);
+
     participant_ = dpf->create_participant(opts.domain, pqos);
 
     if (participant_ == nullptr)

--- a/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
+++ b/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
@@ -147,6 +147,10 @@ bool OrchestratorNode::init()
     DomainParticipantQos dpqos = PARTICIPANT_QOS_DEFAULT;
     dpqos.name("ORCHESTRATOR_NODE");
 
+    //! Set sustainML app ID participant properties
+    dpqos.properties().properties().emplace_back("fastdds.application.id", "SUSTAINML", true);
+    dpqos.properties().properties().emplace_back("fastdds.application.metadata", "", true);
+
     //! Initialize entities
     participant_ = dpf->create_participant(domain_,
                     dpqos,


### PR DESCRIPTION
This PR includes the app id property in participant QoS to identify the SustainML nodes as part of the SustainML framework in the Fast DDS Monitor.

This PR MUST be merged right after:
- #25 